### PR TITLE
Npm stats limit

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -30,6 +30,8 @@ services:
   metrics-db:
     image: mongo
     container_name: metrics-db
+    ports:
+      - "27017:27017"
     restart: always
     env_file:
       - db.env

--- a/zowe-metrics-api/methods/cliController.js
+++ b/zowe-metrics-api/methods/cliController.js
@@ -9,39 +9,37 @@
  *
  */
 
-const npm = require('npm-stats-api');
 const { getSpreadsheetData } = require('../methods/getSpreadsheetData');
+const { cumulativeNpmStats } = require('../methods/npmStatsData');
 
 let cachedCLIData;
 let cachedCLITime;
 
-exports.getCLI = (req, res) => {
+exports.getCLI = async (_, res) => {
     if (cachedCLITime && cachedCLITime > Date.now() - 60 * 1000 * 10) {
         return res.status(200).json(cachedCLIData);
     } else {
         let today = new Date();
-        npm.stat('@zowe/cli', '2019-01-01', today.toISOString().slice(0, 10), async (err, response) => {
-            if (err) {
-                return res.status(500).json({
-                    err: err,
-                });
-            } else {
-                let totalDownloadsFromNPM = parseInt(response.downloads);
-                let spreadsheet = await getSpreadsheetData();
-                let totalDownloadsFromZowe = 0;
-                for (let val of Object.values(spreadsheet.downloads.zoweCLI)) {
-                    totalDownloadsFromZowe += parseInt(val);
-                }
-
-                cachedCLIData = {
-                    zowe: totalDownloadsFromZowe,
-                    npm: totalDownloadsFromNPM,
-                    downloads: totalDownloadsFromZowe + totalDownloadsFromNPM,
-                };
-                cachedCLITime = Date.now();
-
-                return res.status(200).json(cachedCLIData);
+        try {
+            const totalDownloadsFromNPM = await cumulativeNpmStats('@zowe/cli', '2019-01-01', today.toISOString().slice(0, 10));
+            let spreadsheet = await getSpreadsheetData();
+            let totalDownloadsFromZowe = 0;
+            for (let val of Object.values(spreadsheet.downloads.zoweCLI)) {
+                totalDownloadsFromZowe += parseInt(val);
             }
-        });
+
+            cachedCLIData = {
+                zowe: totalDownloadsFromZowe,
+                npm: totalDownloadsFromNPM,
+                downloads: totalDownloadsFromZowe + totalDownloadsFromNPM,
+            };
+            cachedCLITime = Date.now();
+
+            return res.status(200).json(cachedCLIData);
+        } catch (err) {
+            return res.status(500).json({
+                err: err,
+            });
+        }
     }
 };

--- a/zowe-metrics-api/methods/npmStatsData.js
+++ b/zowe-metrics-api/methods/npmStatsData.js
@@ -1,0 +1,46 @@
+const npm = require('npm-stats-api');
+
+const differenceInDays = (startDate, endDate) => {
+    const difference = new Date(endDate.getTime() - startDate.getTime());
+    const diffInDays = difference.getTime() / (1000 * 3600 * 24);
+    return diffInDays;
+}
+
+const npmStats = (packageName, start, end) => new Promise((resolve, reject) => {
+    npm.stat(packageName, start, end, async (err, response) => {
+        if (err) {
+            reject(err);
+            return;
+        } else {
+            resolve(parseInt(response.downloads, 10));
+        }
+    });
+});
+
+/**
+ * Makes requests to npm-stats-api in date ranges dictated by 'maxDays' to overcome the 18 month limit.
+ */
+exports.cumulativeNpmStats = async (packageName, start, end) => {
+    try {
+        let startDate = new Date(start);
+        let endDate = new Date(end);
+        let diffInDays = differenceInDays(startDate, endDate);
+        let totalDownloads = 0;
+        const maxDays = 365;
+        while (diffInDays > maxDays) {
+            let tempEndDate = new Date(startDate);
+            tempEndDate.setDate(startDate.getDate() + maxDays);
+            totalDownloads += await npmStats(
+                packageName,
+                startDate.toISOString().slice(0, 10),
+                tempEndDate.toISOString().slice(0, 10)
+                );
+            startDate.setDate(startDate.getDate() + maxDays + 1);
+            diffInDays = differenceInDays(startDate, endDate);
+        }
+        totalDownloads += await npmStats(packageName, startDate.toISOString().slice(0, 10), end);
+        return totalDownloads;
+    } catch (err) {
+        throw err;
+    }
+}


### PR DESCRIPTION
closes #13; Solution makes requests to `npm-stats-api` in periods of at most 365 days to avoid the 18-month limit.